### PR TITLE
update SLIDER_BASE_URL and SLIDER_EXPLORER to https

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import { utcFormat, utcParse } from "d3-time-format";
 const HIMAWARI_BASE_URL = "https://himawari8-dl.nict.go.jp/himawari8/img/";
 const DSCOVR_BASE_URL = "https://epic.gsfc.nasa.gov/";
 
-const SLIDER_BASE_URL = "http://rammb-slider.cira.colostate.edu/data/";
+const SLIDER_BASE_URL = "https://rammb-slider.cira.colostate.edu/data/";
 
 // links to online image explorers
 const HIMAWARI_EXPLORER = "http://himawari8.nict.go.jp/himawari8-image.htm?sI=D531106";
 const DSCOVR_EXPLORER = "https://epic.gsfc.nasa.gov";
 const DSCOVR_EXPLORER_ENHANCED = DSCOVR_EXPLORER + "/enhanced";
-const SLIDER_EXPLORER = "http://rammb-slider.cira.colostate.edu/";
+const SLIDER_EXPLORER = "https://rammb-slider.cira.colostate.edu/";
 const METEOSAT_EXPLORER = "http://oiswww.eumetsat.org/IPPS/html/MSG/IMAGERY/";
 
 // image types


### PR DESCRIPTION
Awesome extension. No need to look outside anymore to check if the sun is up or not :). But GOES 16 (East) didn't update anymore since 40 something days.

I think its because the data is only available via https and not via http.

If I try this url http://rammb-slider.cira.colostate.edu/data/imagery/20190827/goes-16---full_disk/natural_color/20190827064020/00/000_000.png in Chrome it gets an 301 error and then switch to https.

I've the feeling this is not happening in the extension, but I've now idea how to test this.